### PR TITLE
Fix the regular expression to check the method and extract URI options according to RFC3986:

### DIFF
--- a/src/ews-http.adb
+++ b/src/ews-http.adb
@@ -194,7 +194,8 @@ package body EWS.HTTP is
       pragma Assert (Query_Matches (0) /= GNAT.Regpat.No_Match);
       if Ada.Strings.Fixed.Translate
         (To_String (Query_Input, Query_Matches (Method_Match)),
-         Ada.Strings.Maps.Constants.Upper_Case_Map) in "GET" | "OPTIONS"
+         Ada.Strings.Maps.Constants.Upper_Case_Map)
+        in "GET" | "OPTIONS" | "HEAD"
         and then Query_Matches (Query_Match) /= GNAT.Regpat.No_Match
       then
          declare
@@ -212,7 +213,8 @@ package body EWS.HTTP is
          end;
       elsif Ada.Strings.Fixed.Translate
         (To_String (Query_Input, Query_Matches (Method_Match)),
-         Ada.Strings.Maps.Constants.Upper_Case_Map) = "POST"
+         Ada.Strings.Maps.Constants.Upper_Case_Map)
+        in "POST" | "PUT" | "DELETE" | "PATCH"
         and then SS.Value (From.Content) /= null
       then
          declare


### PR DESCRIPTION
- recognize HEAD, OPTIONS, PUT, DELETE, PATCH methods,
- allow to extract URI options for the HTTP OPTIONS method,
- fix the extraction of query options to take into account the '?'
Fixes #2 