### PR TITLE
Add support to register a default dynamic handler:

### DIFF
--- a/src/ews-dynamic.adb
+++ b/src/ews-dynamic.adb
@@ -40,6 +40,7 @@ package body EWS.Dynamic is
    end record;
 
    Registry : Cell_P;
+   Default_Creator  : Creator;
 
 
    procedure Free
@@ -141,6 +142,9 @@ package body EWS.Dynamic is
          end if;
          Reg := Reg.Next;
       end loop;
+      if Default_Creator /= null then
+         return Default_Creator (HTTP.Request_P (For_Request));
+      end if;
       return HTTP.Not_Found (For_Request);
    end Find;
 
@@ -159,6 +163,10 @@ package body EWS.Dynamic is
                             Next => Registry);
    end Register;
 
+   procedure Register_Default (The_Creator : not null Creator) is
+   begin
+      Default_Creator := The_Creator;
+   end Register_Default;
 
    procedure Set_Content (This : in out Dynamic_Response;
                           To : String) is

--- a/src/ews-dynamic.ads
+++ b/src/ews-dynamic.ads
@@ -44,6 +44,7 @@ package EWS.Dynamic with Elaborate_Body is
    --  In "http://foo.com:1234/bar", for example, the URL is "/bar".
    procedure Register (The_Creator : not null Creator;
                        For_The_URL :          HTTP.URL);
+   procedure Register_Default (The_Creator : not null Creator);
 
    --  Operations callable by Creator functions.
    procedure Set_Content_Type (This : in out Dynamic_Response;


### PR DESCRIPTION
- declare and implement Register_Default handler
- if a default handler exists, use it instead of the HTTP.Not_Found handler
  otherwise continue using the HTTP.Not_Found
This fixes #4 