### PR TITLE
Prototype of Alire crate for EWS

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,26 @@
+description = "Embedded Web Server"
+long-description = """
+
+EWS is a web server construction kit, designed for embedded applications using the GNAT Ada compiler.
+
+The project is hosted on [Github](https://github.com/simonjwright/ews).
+
+"""
+name = "ews"
+version = "2022"
+authors = ["Simon Wright <simon@pushface.org>"]
+licenses = "GPL-3.0-only WITH GCC-exception-3.1"
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+project-files = ["ews.gpr"]
+tags = ["web", "server"]
+website = "https://github.com/simonjwright/ews"
+
+[[depends-on]]
+xmlada = "any"
+
+[gpr-externals]
+LIBRARY_TYPE = ["relocatable", "static"]
+
+[configuration]
+disabled = true


### PR DESCRIPTION
I've made the attached Alire crate. I think it would be good that you publish it in the Alire index so that EWS be integrated and can be used from Alire environment.

The version number is not clear for me so I picked the 2022 number.

May be the description could be longer.

As far as I'm concerned, I have created several crates of some of my libraries that now use this `ews`crate. I'm using my own crate index so I can use that `ews` definition in it but a more public access would be great!

FYI, I'm now able to run my complete Ada Web Application framework on top of EWS.
Blog, Wiki, Q&A, Google OAuth2 authentication are working well so the support for query parameters, forms, headers, binary responses etc are working. The only thing I've not yet done is the file upload.